### PR TITLE
Adds shielded button and functionality (transparent -> orchard[unified]) to zingo-pc

### DIFF
--- a/src/components/receive/Receive.tsx
+++ b/src/components/receive/Receive.tsx
@@ -76,8 +76,6 @@ export default class Receive extends Component<ReceiveProps> {
       return m;
     }, new Map());
 
-    console.log('<Receive />')
-
     return (
       <div>
         <div className={styles.receivecontainer}>

--- a/src/components/receive/Receive.tsx
+++ b/src/components/receive/Receive.tsx
@@ -13,7 +13,8 @@ type ReceiveProps = {
   fetchAndSetSinglePrivKey: (k: string) => void;
   fetchAndSetSingleViewKey: (k: string) => void;
   //createNewAddress: (t: AddressType) => void;
-  shieldBalanceToOrchard: () => void;
+  shieldTransparentBalanceToOrchard: () => void;
+  shieldSaplingBalanceToOrchard: () => void;
 };
 
 export default class Receive extends Component<ReceiveProps> {
@@ -23,7 +24,8 @@ export default class Receive extends Component<ReceiveProps> {
       fetchAndSetSinglePrivKey,
       fetchAndSetSingleViewKey,
       //createNewAddress,
-      shieldBalanceToOrchard
+      shieldTransparentBalanceToOrchard,
+      shieldSaplingBalanceToOrchard
     } = this.props;
     const {
       addresses,
@@ -100,7 +102,8 @@ export default class Receive extends Component<ReceiveProps> {
                       viewKey={addressViewKeys.get(a.address)}
                       fetchAndSetSinglePrivKey={fetchAndSetSinglePrivKey}
                       fetchAndSetSingleViewKey={fetchAndSetSingleViewKey}
-                      shieldBalanceToOrchard={shieldBalanceToOrchard}
+                      shieldTransparentBalanceToOrchard={shieldTransparentBalanceToOrchard}
+                      shieldSaplingBalanceToOrchard={shieldSaplingBalanceToOrchard}
                     />
                   ))}
                 </Accordion>
@@ -130,7 +133,8 @@ export default class Receive extends Component<ReceiveProps> {
                       viewKey={addressViewKeys.get(a.address)}
                       fetchAndSetSinglePrivKey={fetchAndSetSinglePrivKey}
                       fetchAndSetSingleViewKey={fetchAndSetSingleViewKey}
-                      shieldBalanceToOrchard={shieldBalanceToOrchard}
+                      shieldTransparentBalanceToOrchard={shieldTransparentBalanceToOrchard}
+                      shieldSaplingBalanceToOrchard={shieldSaplingBalanceToOrchard}
                     />
                   ))}
                 </Accordion>
@@ -159,7 +163,8 @@ export default class Receive extends Component<ReceiveProps> {
                       viewKey={addressViewKeys.get(a.address)}
                       fetchAndSetSinglePrivKey={fetchAndSetSinglePrivKey}
                       fetchAndSetSingleViewKey={fetchAndSetSingleViewKey}
-                      shieldBalanceToOrchard={shieldBalanceToOrchard}
+                      shieldTransparentBalanceToOrchard={shieldTransparentBalanceToOrchard}
+                      shieldSaplingBalanceToOrchard={shieldSaplingBalanceToOrchard}
                     />
                   ))}
                 </Accordion>

--- a/src/components/receive/Receive.tsx
+++ b/src/components/receive/Receive.tsx
@@ -13,6 +13,7 @@ type ReceiveProps = {
   fetchAndSetSinglePrivKey: (k: string) => void;
   fetchAndSetSingleViewKey: (k: string) => void;
   //createNewAddress: (t: AddressType) => void;
+  shieldBalanceToOrchard: () => void;
 };
 
 export default class Receive extends Component<ReceiveProps> {
@@ -22,6 +23,7 @@ export default class Receive extends Component<ReceiveProps> {
       fetchAndSetSinglePrivKey,
       fetchAndSetSingleViewKey,
       //createNewAddress,
+      shieldBalanceToOrchard
     } = this.props;
     const {
       addresses,
@@ -74,6 +76,8 @@ export default class Receive extends Component<ReceiveProps> {
       return m;
     }, new Map());
 
+    console.log('<Receive />')
+
     return (
       <div>
         <div className={styles.receivecontainer}>
@@ -98,6 +102,7 @@ export default class Receive extends Component<ReceiveProps> {
                       viewKey={addressViewKeys.get(a.address)}
                       fetchAndSetSinglePrivKey={fetchAndSetSinglePrivKey}
                       fetchAndSetSingleViewKey={fetchAndSetSingleViewKey}
+                      shieldBalanceToOrchard={shieldBalanceToOrchard}
                     />
                   ))}
                 </Accordion>
@@ -127,6 +132,7 @@ export default class Receive extends Component<ReceiveProps> {
                       viewKey={addressViewKeys.get(a.address)}
                       fetchAndSetSinglePrivKey={fetchAndSetSinglePrivKey}
                       fetchAndSetSingleViewKey={fetchAndSetSingleViewKey}
+                      shieldBalanceToOrchard={shieldBalanceToOrchard}
                     />
                   ))}
                 </Accordion>
@@ -155,6 +161,7 @@ export default class Receive extends Component<ReceiveProps> {
                       viewKey={addressViewKeys.get(a.address)}
                       fetchAndSetSinglePrivKey={fetchAndSetSinglePrivKey}
                       fetchAndSetSingleViewKey={fetchAndSetSingleViewKey}
+                      shieldBalanceToOrchard={shieldBalanceToOrchard}
                     />
                   ))}
                 </Accordion>

--- a/src/components/receive/components/AddressBlock.tsx
+++ b/src/components/receive/components/AddressBlock.tsx
@@ -22,7 +22,8 @@ type AddressBlockProps = {
   label?: string;
   fetchAndSetSinglePrivKey: (k: string) => void;
   fetchAndSetSingleViewKey: (k: string) => void;
-  shieldBalanceToOrchard: () => void;
+  shieldTransparentBalanceToOrchard: () => void;
+  shieldSaplingBalanceToOrchard: () => void;
 };
 
 const AddressBlock = ({
@@ -34,7 +35,8 @@ const AddressBlock = ({
   fetchAndSetSinglePrivKey,
   viewKey,
   fetchAndSetSingleViewKey,
-  shieldBalanceToOrchard
+  shieldTransparentBalanceToOrchard,
+  shieldSaplingBalanceToOrchard
 }: AddressBlockProps) => {
   const { receivers, type } = address;
   const address_address = address.address;
@@ -174,8 +176,13 @@ const AddressBlock = ({
                 </button>
               )}
               {type === AddressType.transparent && (
-                <button className={[cstyles.primarybutton].join(" ")} type="button" onClick={shieldBalanceToOrchard}>
-                  Shield Balance
+                <button className={[cstyles.primarybutton].join(" ")} type="button" onClick={shieldTransparentBalanceToOrchard}>
+                  Shield Balance To Orchard
+                </button>
+              )}
+              {type === AddressType.sapling && (
+                <button className={[cstyles.primarybutton].join(" ")} type="button" onClick={shieldSaplingBalanceToOrchard}>
+                  Shield Balance To Orchard
                 </button>
               )}
             </div>

--- a/src/components/receive/components/AddressBlock.tsx
+++ b/src/components/receive/components/AddressBlock.tsx
@@ -59,8 +59,6 @@ const AddressBlock = ({
     }
   };
 
-  console.log('<AddressBlock />')
-
   return (
     <AccordionItem key={copied ? 1 : 0} className={[cstyles.well, styles.receiveblock].join(" ")} uuid={address_address}>
       <AccordionItemHeading>

--- a/src/components/receive/components/AddressBlock.tsx
+++ b/src/components/receive/components/AddressBlock.tsx
@@ -22,6 +22,7 @@ type AddressBlockProps = {
   label?: string;
   fetchAndSetSinglePrivKey: (k: string) => void;
   fetchAndSetSingleViewKey: (k: string) => void;
+  shieldBalanceToOrchard: () => void;
 };
 
 const AddressBlock = ({
@@ -33,6 +34,7 @@ const AddressBlock = ({
   fetchAndSetSinglePrivKey,
   viewKey,
   fetchAndSetSingleViewKey,
+  shieldBalanceToOrchard
 }: AddressBlockProps) => {
   const { receivers, type } = address;
   const address_address = address.address;
@@ -56,6 +58,8 @@ const AddressBlock = ({
       shell.openExternal(`https://zecblockexplorer.com/address/${address_address}`);
     }
   };
+
+  console.log('<AddressBlock />')
 
   return (
     <AccordionItem key={copied ? 1 : 0} className={[cstyles.well, styles.receiveblock].join(" ")} uuid={address_address}>
@@ -169,6 +173,11 @@ const AddressBlock = ({
               {type === AddressType.transparent && (
                 <button className={[cstyles.primarybutton].join(" ")} type="button" onClick={() => openAddress()}>
                   View on explorer <i className={["fas", "fa-external-link-square-alt"].join(" ")} />
+                </button>
+              )}
+              {type === AddressType.transparent && (
+                <button className={[cstyles.primarybutton].join(" ")} type="button" onClick={shieldBalanceToOrchard}>
+                  Shield Balance
                 </button>
               )}
             </div>

--- a/src/root/Routes.tsx
+++ b/src/root/Routes.tsx
@@ -447,9 +447,23 @@ class Routes extends React.Component<Props & RouteComponentProps, AppState> {
     this.rpc.clearTimers();
   };
 
-  shieldBalanceToOrchard = async () => {
+  shieldSaplingBalanceToOrchard = async () => {
     try {
-    const result = await this.rpc.shieldBalanceToOrchard()
+    const result = await this.rpc.shieldSaplingBalanceToOrchard()
+
+    if (!result.includes('txid')) {
+      throw new Error(result)
+    }
+
+    } catch(error) {
+      this.openErrorModal('Failed to shield balance', String(error))
+    }
+
+  }
+
+  shieldTransparentBalanceToOrchard = async () => {
+    try {
+    const result = await this.rpc.shieldTransparentBalanceToOrchard()
 
     if (!result.includes('txid')) {
       throw new Error(result)
@@ -524,7 +538,8 @@ class Routes extends React.Component<Props & RouteComponentProps, AppState> {
                 render={() => (
                   <Receive
                     {...standardProps}
-                    shieldBalanceToOrchard={this.shieldBalanceToOrchard}
+                    shieldTransparentBalanceToOrchard={this.shieldTransparentBalanceToOrchard}
+                    shieldSaplingBalanceToOrchard={this.shieldSaplingBalanceToOrchard}
                     fetchAndSetSinglePrivKey={this.fetchAndSetSinglePrivKey}
                     fetchAndSetSingleViewKey={this.fetchAndSetSingleViewKey}
                   />

--- a/src/root/Routes.tsx
+++ b/src/root/Routes.tsx
@@ -366,6 +366,8 @@ class Routes extends React.Component<Props & RouteComponentProps, AppState> {
     }
   };
 
+  
+
   // Get a single private key for this address, and return it as a string.
   // Wallet needs to be unlocked
   getPrivKeyAsString = (address: string): string => {
@@ -445,6 +447,20 @@ class Routes extends React.Component<Props & RouteComponentProps, AppState> {
     this.rpc.clearTimers();
   };
 
+  shieldBalanceToOrchard = async () => {
+    try {
+    const result = await this.rpc.shieldBalanceToOrchard()
+
+    if (!result.includes('txid')) {
+      throw new Error(result)
+    }
+
+    } catch(error) {
+      this.openErrorModal('Failed to shield balance', String(error))
+    }
+
+  }
+
   navigateToLoadingScreen = () => {
     this.props.history.push(routes.LOADING);
   };
@@ -508,6 +524,7 @@ class Routes extends React.Component<Props & RouteComponentProps, AppState> {
                 render={() => (
                   <Receive
                     {...standardProps}
+                    shieldBalanceToOrchard={this.shieldBalanceToOrchard}
                     fetchAndSetSinglePrivKey={this.fetchAndSetSinglePrivKey}
                     fetchAndSetSingleViewKey={this.fetchAndSetSingleViewKey}
                   />

--- a/src/rpc/rpc.ts
+++ b/src/rpc/rpc.ts
@@ -133,16 +133,27 @@ export default class RPC {
     console.log(`Deinitialize status: ${str}`);
   }
 
-  static doShield(): string {
-    const shieldstr = native.zingolib_execute("shield", "all");
+  static doShield(poolToShield: string): string {
+    const shieldstr = native.zingolib_execute("shield", poolToShield);
     console.log(`Shield status: ${shieldstr}`)
     return shieldstr;
   }
 
   // shield transparent balance to orchard
-  async shieldBalanceToOrchard(): Promise<string> {
+  async shieldTransparentBalanceToOrchard(): Promise<string> {
     try {
-      const result = await RPC.doShield();
+      const result = await RPC.doShield('transparent');
+      this.updateData()
+      return String(result)
+    } catch(error) {
+      console.log(`Error while trying to shield balance ${{error}}`)
+      return JSON.stringify(error)
+    }
+  }
+
+  async shieldSaplingBalanceToOrchard(): Promise<string> {
+    try {
+      const result = await RPC.doShield('sapling');
       this.updateData()
       return String(result)
     } catch(error) {


### PR DESCRIPTION
**Proposed changes**
 Creates new rpc functions doShield and shieldBalanceToOrchard. Adds shieldBalanceToOrchard to <AddressBook />. Adds shieldBalanceToOrchard to <Receive />.

**General Notes**
Note: This merge request may only be seen as a draft as there are some questions that will probably need to be addressed:

1. Is this the desired placement of the Shield button? 
2. The UI freezes during the "shielding" operation.  I can tackle a general UI loader in this PR or leave the PR to this one issue.
3. I used my prettier config on these files without much thought. I can revert the prettier changes or create a new PR without the prettier changes.

**Visuals**
_New Button (This button is "Shield Balance" now)_

<img width="1345" alt="Captura de pantalla 2023-06-03 a la(s) 6 26 14 p m" src="https://github.com/zingolabs/zingo-pc/assets/26151387/502e6533-24c5-496c-a364-0644604e93cd">


_Working Error State_

<img width="1345" alt="Captura de pantalla 2023-06-03 a la(s) 6 26 33 p m" src="https://github.com/zingolabs/zingo-pc/assets/26151387/08da76df-a6b3-4fae-95ee-428884125cc1">

_See list of transactions here. This involves a number of transactions I made sending ZEC to my transparent address and shielding it._

https://blockchair.com/zcash/address/t1Zs9uxRyN6Knd6kDHfRKjLjn5JchnAPFN8


_Transparent Balance After Shielding_

<img width="1345" alt="Captura de pantalla 2023-06-04 a la(s) 2 20 22 p m" src="https://github.com/zingolabs/zingo-pc/assets/26151387/0d30e1dd-9e61-454d-b82b-5371907787b2">

_Orchard (Unified) Balance After Shielding_

<img width="1345" alt="Captura de pantalla 2023-06-04 a la(s) 2 20 28 p m" src="https://github.com/zingolabs/zingo-pc/assets/26151387/09217f08-41f1-4098-b550-367cb352fcc4">





