### PR TITLE
Upgrading to `ring` 0.17.x

### DIFF
--- a/native/Cargo.lock
+++ b/native/Cargo.lock
@@ -1003,13 +1003,12 @@ checksum = "1e087f84d4f86bf4b218b927129862374b72199ae7d8657835f1e89000eea4fb"
 
 [[package]]
 name = "hdwallet"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a03ba7d4c9ea41552cd4351965ff96883e629693ae85005c501bb4b9e1c48a7"
+version = "0.4.2"
+source = "git+https://github.com/juanky201271/hdwallet?rev=13d36401100671e57a9a9b19942c77e06d3b0507#13d36401100671e57a9a9b19942c77e06d3b0507"
 dependencies = [
  "lazy_static",
  "rand_core 0.6.4",
- "ring 0.16.20",
+ "ring 0.17.8",
  "secp256k1",
  "thiserror",
 ]

--- a/native/Cargo.toml
+++ b/native/Cargo.toml
@@ -22,3 +22,6 @@ tokio =  { version = "1.24", features = [ "full" ] }
 version = "0.10.1"
 default-features = false
 features = ["napi-6", "promise-api", "channel-api"]
+
+[patch.crates-io]
+hdwallet = { git = "https://github.com/juanky201271/hdwallet", rev = "13d36401100671e57a9a9b19942c77e06d3b0507" }


### PR DESCRIPTION
In order to build the App in Windows arm64 we need to upgrade to `ring` 0.17.x.
- using this fork for hdwallet: https://github.com/juanky201271/hdwallet