### PR TITLE
Replace lodash with native deepEqual to remove vulnerable dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
     "electron-settings": "^4.0.4",
     "fs-extra": "^9.0.1",
     "js-base64": "^3.7.7",
-    "lodash": "4.17.21",
     "minimatch": "^10.0.3",
     "progress-stream": "^2.0.0",
     "qrcode.react": "^4.2.0",

--- a/src/root/Routes.tsx
+++ b/src/root/Routes.tsx
@@ -1,7 +1,6 @@
 import React from "react";
 import ReactModal from "react-modal";
 import { Switch, Route, withRouter, RouteComponentProps } from "react-router";
-import { isEqual } from "lodash";
 import { ErrorModal } from "../components/errorModal";
 import cstyles from "../components/common/Common.module.css";
 import routes from "../constants/routes.json";
@@ -42,6 +41,10 @@ import { ConfirmModal } from "../components/confirmModal";
 import ShieldResultContent from "./ShieldResultContent";
 
 type Props = {};
+
+function deepEqual(a: unknown, b: unknown): boolean {
+  return JSON.stringify(a) === JSON.stringify(b);
+}
 
 class Routes extends React.Component<Props & RouteComponentProps, AppState> {
   rpc: RPC;
@@ -119,7 +122,7 @@ class Routes extends React.Component<Props & RouteComponentProps, AppState> {
   };
 
   setTotalBalance = (totalBalance: TotalBalanceClass) => {
-    if (!isEqual(totalBalance, this.state.totalBalance)) {
+    if (!deepEqual(totalBalance, this.state.totalBalance)) {
       //console.log('=============== total SPENDABLE balance', totalBalance.totalSpendableBalance);
       //console.log('=============== total balance', totalBalance);
       this.setState({ totalBalance });
@@ -142,28 +145,28 @@ class Routes extends React.Component<Props & RouteComponentProps, AppState> {
   };
 
   setAddressesUnified = (addressesUnified: UnifiedAddressClass[]) => {
-    if (!isEqual(addressesUnified, this.state.addressesUnified)) {
+    if (!deepEqual(addressesUnified, this.state.addressesUnified)) {
       console.log("=============== addresses UA", addressesUnified.length);
       this.setState({ addressesUnified });
     }
   };
 
   setAddressesTransparent = (addressesTransparent: TransparentAddressClass[]) => {
-    if (!isEqual(addressesTransparent, this.state.addressesTransparent)) {
+    if (!deepEqual(addressesTransparent, this.state.addressesTransparent)) {
       console.log("=============== addresses T", addressesTransparent.length);
       this.setState({ addressesTransparent });
     }
   };
 
   setValueTransferList = (valueTransfers: ValueTransferClass[]) => {
-    if (!isEqual(valueTransfers, this.state.valueTransfers)) {
+    if (!deepEqual(valueTransfers, this.state.valueTransfers)) {
       console.log("=============== ValueTransfer list", valueTransfers.length);
       this.setState({ valueTransfers });
     }
   };
 
   setMessagesList = (messages: ValueTransferClass[]) => {
-    if (!isEqual(messages, this.state.messages)) {
+    if (!deepEqual(messages, this.state.messages)) {
       console.log("=============== ValueTransfer Messages list", messages.length);
       this.setState({ messages });
     }
@@ -228,7 +231,7 @@ class Routes extends React.Component<Props & RouteComponentProps, AppState> {
   };
 
   setInfo = (newInfo: InfoClass) => {
-    if (!isEqual(newInfo, this.state.info)) {
+    if (!deepEqual(newInfo, this.state.info)) {
       console.log("=============== info", newInfo);
       // If the price is not set in this object, copy it over from the current object
       const { info } = this.state;
@@ -241,7 +244,7 @@ class Routes extends React.Component<Props & RouteComponentProps, AppState> {
   };
 
   setSyncStatus = (syncingStatus: SyncStatusType) => {
-    if (!isEqual(this.state.syncingStatus, syncingStatus)) {
+    if (!deepEqual(this.state.syncingStatus, syncingStatus)) {
       this.setState({ syncingStatus });
     }
   };

--- a/yarn.lock
+++ b/yarn.lock
@@ -9074,11 +9074,6 @@ lodash.uniq@^4.5.0:
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
   integrity sha512-xfBaXQd9ryd9dlSDvnvI0lvxfLJlYAZzXomUYzLKtUeOQvOP5piqAWuGtrhWeqaXK9hhoM/iyJc5AV+XfsX3HQ==
 
-lodash@4.17.21:
-  version "4.17.21"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
-  integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
-
 "lodash@>=3.5 <5", lodash@^4.0.1, lodash@^4.17.11, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.20, lodash@^4.17.21, lodash@^4.17.5:
   version "4.17.23"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.23.tgz#f113b0378386103be4f6893388c73d0bde7f2c5a"


### PR DESCRIPTION
- Remove lodash from dependencies (4.17.21 has Prototype Pollution and Code Injection via _.template with no patch available in 4.x)
- Replace all isEqual() calls with a local deepEqual() using JSON.stringify (safe for plain state objects: numbers, strings, class instances)
- Reduces production vulnerability count from 11 to 6