### PR TITLE
feat!: the price display goes dark until mixnet convergence (ADR 0024 arc 6)

### DIFF
--- a/docs/agents/adr0024-neon-boundary-map.md
+++ b/docs/agents/adr0024-neon-boundary-map.md
@@ -1,0 +1,81 @@
+# The neon boundary, mapped against ADR 0024
+
+Surveyed 2026-07-28 as phase-3 pre-work for ADR 0024 ("Consumers
+converge on a zingolib-owned mixnet surface", recorded in the zingolib
+repo at docs/adr/0024). That ADR sequences zingo-pc last. This map
+records where its typed contract will land in this codebase, so the
+phase-3 implementer starts from facts instead of a fresh audit.
+
+## The call path
+
+Every wallet call crosses three boundaries. The renderer imports
+`native` from `src/electronBridge.ts`, which is the preload's
+`window.electronAPI.native`. The preload (`public/preload.js`) builds
+that object from `_ALL_NATIVE_METHODS`, one `ipcRenderer.invoke("native:X")`
+relay per method. The main process (`public/electron.js`) answers each
+with an `ipcMain.handle("native:X")` that calls the neon module, and
+the neon crate (`native/src/lib.rs`) finally calls zingolib. Adding a
+wallet function therefore touches four files: `lib.rs` (the fn and its
+`export_function`), `native.node.d.ts`, `preload.js`, and
+`electron.js`.
+
+## The surface
+
+`native/src/lib.rs` exports 73 functions. The TypeScript declaration
+(`src/native.node.d.ts`) types 58 of them as `Promise<string>`, and the
+strings are pretty-printed JSON built ad hoc with the `json::object!`
+macro. This is the "stringly JSON boundary" the ADR's audit measured.
+
+Errors are worse than the results: 66 of the export sites end in
+`cx.throw_error(err.to_string())`, so every failure crosses as prose
+and typed evidence dies at the boundary. ADR 0024 arc 5 lands here.
+The convergence keeps neon but carries zingolib's serde serialization
+of the wire types (the five mixnet states, the typed status struct,
+typed errors), pinned by golden fixtures, with the TS side matching
+variants instead of substrings.
+
+## Eventing
+
+There is none. `lib.rs` uses no neon `Channel` and takes no JS
+callbacks. All status is polled: `poll_sync`, `status_sync`,
+`migration_status`, and the renderer's 5-second `runTaskPromises`
+cycle. Arc 2's status-by-subscription therefore needs a new push path:
+a neon `Channel` from the driver's subscription into the main process,
+then a main-to-renderer IPC event, which must be added to the
+preload's `ALLOWED_RECEIVE` allowlist.
+
+## Spawn-versus-attach discrimination
+
+Already plumbed. `public/electron.js` branches on `process.mas` at
+runtime in about ten places, and the preload exposes
+`isSandboxed = process.platform === "darwin" && process.mas === true`
+to the renderer. The attach strategy for the Mac App Store build has
+its hook. Flatpak note: the sandbox checks treat `process.mas` and
+`FLATPAK_ID` alike, and a Flatpak cannot spawn an arbitrary bundled
+binary either, so phase 3 should decide whether Flatpak also attaches.
+
+## Dependencies
+
+`native/Cargo.toml` already pins zingolib by rev (79d575bf), matching
+arc 7's rev-not-branch rule. It also declares direct `pepper-sync` and
+`zingo-netutils` dependencies. The netutils use is a single import,
+`zingo_netutils::{GrpcIndexer, Indexer}` at `lib.rs:68`, which retires
+once zingolib's re-exports (the phase-1 funnel on the zls side) reach
+a pinned rev. Unlike zingo-mobile, pc compiles exactly one copy of
+zingo-netutils, because all its git pins agree on the rev. The
+pepper-sync imports (config, keys, wallet, error types) are wider than
+the funnel's netutils scope and are not addressed by ADR 0024.
+
+## Price
+
+Dark as of this survey, deliberately, per arc 6 and the ADR's
+consequences section. The clearnet fetch is removed end to end: the
+renderer's `getZecPrice` scheduler, the `fnSetZecPrice` wiring, the
+preload and main relays, the neon `zec_price` export, and its
+`.d.ts` declaration. The display machinery stays: `zecPrice` state in
+`Routes.tsx` holds 0 and every USD display renders the unified
+`USD --` fallback (`src/components/usdValue/UsdValue.tsx`). Phase 3
+re-lands price as a typed subscription from zingolib's driver, which
+refuses price in every state except ready. The per-transaction
+`zec_price` field on value transfers is historical data from the
+wallet, not a live fetch, and is untouched.

--- a/native/src/lib.rs
+++ b/native/src/lib.rs
@@ -133,7 +133,6 @@ fn main(mut cx: ModuleContext) -> NeonResult<()> {
     cx.export_function("get_total_memobytes_to_address", get_total_memobytes_to_address)?;
     cx.export_function("get_total_value_to_address", get_total_value_to_address)?;
     cx.export_function("get_total_spends_to_address", get_total_spends_to_address)?;
-    cx.export_function("zec_price", zec_price)?;
     cx.export_function("drain_orchard_to_ironwood", drain_orchard_to_ironwood)?;
     cx.export_function("drain_status", drain_status)?;
     cx.export_function("get_ironwood_activation_height", get_ironwood_activation_height)?;
@@ -2476,33 +2475,6 @@ fn execute_due_parts_status(mut cx: FunctionContext) -> JsResult<JsPromise> {
                     }
                     .pretty(2)),
                     None => Ok(object! { "idle" => true }.pretty(2)),
-                }
-            })
-        })
-        .promise(move |mut cx, result| match result {
-            Ok(msg) => Ok(cx.string(msg)),
-            Err(err) => cx.throw_error(err.to_string()),
-        });
-
-    Ok(promise)
-}
-
-fn zec_price(mut cx: FunctionContext) -> JsResult<JsPromise> {
-    let promise = cx
-        .task(move || -> Result<String, ZingolibError> {
-            with_panic_guard(|| {
-                let mut guard = LIGHTCLIENT.write().map_err(|_| ZingolibError::LightclientLockPoisoned)?;
-                if let Some(lightclient) = &mut *guard {
-                    RT.block_on(async move {
-                        // update_current_price moved onto the lightclient (was on the
-                        // wallet write guard, and took a socks5 arg).
-                        match lightclient.update_current_price().await {
-                            Ok(price) => Ok(object! { "current_price" => price }.pretty(2)),
-                            Err(e) => Err(ZingolibError::Read(e.to_string())),
-                        }
-                    })
-                } else {
-                    Err(ZingolibError::LightclientNotInitialized)
                 }
             })
         })

--- a/public/electron.js
+++ b/public/electron.js
@@ -898,7 +898,6 @@ ipcMain.handle("native:get_latest_block_server", (_e, server_uri) => getNative()
 ipcMain.handle("native:parse_address", (_e, address) => getNative().parse_address(address));
 ipcMain.handle("native:parse_ufvk", (_e, ufvk) => getNative().parse_ufvk(ufvk));
 ipcMain.handle("native:get_messages", (_e, address) => getNative().get_messages(address));
-ipcMain.handle("native:zec_price", () => getNative().zec_price());
 ipcMain.handle("native:remove_transaction", (_e, txid) => getNative().remove_transaction(txid));
 ipcMain.handle("native:get_spendable_balance_with_address", (_e, address, zennies) =>
   getNative().get_spendable_balance_with_address(address, zennies),

--- a/public/preload.js
+++ b/public/preload.js
@@ -62,7 +62,6 @@ const _ALL_NATIVE_METHODS = [
   "parse_address",
   "parse_ufvk",
   "get_messages",
-  "zec_price",
   "remove_transaction",
   "get_spendable_balance_with_address",
   "create_new_unified_address",

--- a/src/components/appstate/AppState.ts
+++ b/src/components/appstate/AppState.ts
@@ -85,8 +85,9 @@ export default class AppState {
   handleShieldButton: () => void;
   setAddLabel: (a: AddressBookEntryClass) => void;
 
-  // Current USD price per ZEC. Refreshed every 5s by RPC.getZecPrice() via
-  // the runTaskPromises scheduler. Lives at the top level (not inside
+  // Current USD price per ZEC. Nothing fetches it today: the clearnet
+  // fetch is removed until the mixnet convergence lands a typed price
+  // surface (ADR 0024 arc 6). Lives at the top level (not inside
   // InfoClass) because the periodic info-refresh rebuilds InfoClass and
   // would otherwise clobber the price between cycles. 0 means "no price
   // available right now" — all USD displays render `--` in that case.

--- a/src/native.node.d.ts
+++ b/src/native.node.d.ts
@@ -67,7 +67,6 @@ export function get_balance(): Promise<string>;
 export function get_total_memobytes_to_address(): Promise<string>;
 export function get_total_value_to_address(): Promise<string>;
 export function get_total_spends_to_address(): Promise<string>;
-export function zec_price(): Promise<string>;
 export function remove_transaction(txid: string): Promise<string>;
 export function get_spendable_balance_with_address(address: string, zennies: string): Promise<string>;
 export function get_spendable_balance_total(): Promise<string>;

--- a/src/root/Routes.tsx
+++ b/src/root/Routes.tsx
@@ -136,7 +136,9 @@ const AppRoutes: React.FC = () => {
 
   // ZEC price. Lives at the top level (NOT inside InfoClass) because the
   // periodic info-refresh rebuilds InfoClass and would otherwise clobber it
-  // every 5s cycle. Updated by RPC.getZecPrice on each fetch.
+  // every 5s cycle. Nothing fetches it today: the clearnet fetch is removed
+  // until the mixnet convergence lands a typed price surface (ADR 0024
+  // arc 6), so it stays 0 and the UI renders its `USD --` fallback.
   const [zecPrice, setZecPriceState] = useState<number>(0);
   const setZecPrice = useCallback((price?: number) => {
     if (typeof price === "number") setZecPriceState(price);
@@ -199,7 +201,6 @@ const AppRoutes: React.FC = () => {
       setValueTransferList,
       setMessagesList,
       setInfo,
-      setZecPrice,
       setSyncStatus,
       setVerificationProgress,
       setFetchError,

--- a/src/rpc/rpc.ts
+++ b/src/rpc/rpc.ts
@@ -44,7 +44,6 @@ export default class RPC {
   fnSetValueTransfersList: (t: ValueTransferClass[]) => void;
   fnSetMessagesList: (t: ValueTransferClass[]) => void;
   fnSetInfo: (info: InfoClass) => void;
-  fnSetZecPrice: (p?: number) => void;
   fnSetSyncStatus: (ss: SyncStatusType) => void;
   fnSetVerificationProgress: (verificationProgress: number | null) => void;
   fnSetFetchError: (command: string, error: string) => void;
@@ -66,7 +65,6 @@ export default class RPC {
     fnSetValueTransfersList: (t: ValueTransferClass[]) => void,
     fnSetMessagesList: (t: ValueTransferClass[]) => void,
     fnSetInfo: (info: InfoClass) => void,
-    fnSetZecPrice: (p?: number) => void,
     fnSetSyncStatus: (ss: SyncStatusType) => void,
     fnSetVerificationProgress: (verificationProgress: number | null) => void,
     fnSetFetchError: (command: string, error: string) => void,
@@ -78,7 +76,6 @@ export default class RPC {
     this.fnSetValueTransfersList = fnSetValueTransfersList;
     this.fnSetMessagesList = fnSetMessagesList;
     this.fnSetInfo = fnSetInfo;
-    this.fnSetZecPrice = fnSetZecPrice;
     this.fnSetSyncStatus = fnSetSyncStatus;
     this.fnSetVerificationProgress = fnSetVerificationProgress;
     this.fnSetFetchError = fnSetFetchError;
@@ -99,7 +96,6 @@ export default class RPC {
       this.fetchInfo(),
       this.fetchAddresses(),
       this.fetchTotalBalance(),
-      this.getZecPrice(),
       RPC.doSave(),
       this.fetchTandZandOValueTransfers(),
       this.fetchTandZandOMessages(),
@@ -115,7 +111,6 @@ export default class RPC {
     await this.fetchAddresses();
     await this.fetchTotalBalance();
     await this.fetchInfo();
-    void this.getZecPrice();
     await this.fetchTandZandOMessages();
 
     // Reconcile any in-progress private migration on launch (no-op otherwise):
@@ -234,10 +229,9 @@ export default class RPC {
       info.currencyName = info.chainName === ServerChainNameEnum.mainChainName ? "ZEC" : "TAZ";
       info.solps = 0;
 
-      // ZEC price is no longer fetched here — it lives outside InfoClass
-      // (see `getZecPrice` below, scheduled by `runTaskPromises`). Folding
-      // the price fetch into the info refresh meant that every 5s cycle
-      // overwrote the Tor-fetched value with a hard-coded `false` HTTP call.
+      // ZEC price is not fetched at all: the clearnet fetch is removed until
+      // the mixnet convergence lands a typed price surface (ADR 0024 arc 6).
+      // The UI renders its `USD --` fallback meanwhile.
 
       // zingolib version
       let zingolibStr: string = await native.get_version();
@@ -1110,31 +1104,6 @@ export default class RPC {
     } catch (error) {
       console.error(`Error cancel ironwood migration ${error}`);
       return false;
-    }
-  }
-
-  async getZecPrice() {
-    // Skip the network call entirely on testnet / regtest: TAZ has no USD
-    // price and the UI doesn't render the value anyway (see BalanceBlock,
-    // which only shows USD when currencyName === "ZEC"). Avoids unnecessary
-    // HTTP traffic every 5s on a testnet wallet. Wallet switches already
-    // reset the cached price via setZecPrice(0) in Routes.tsx.
-    if (this.currentWallet && this.currentWallet.chain_name !== ServerChainNameEnum.mainChainName) {
-      return;
-    }
-
-    try {
-      const resultStr: string = await native.zec_price();
-
-      if (!resultStr) {
-        console.error(`zec_price returned empty result`);
-        this.fnSetZecPrice(0);
-        return;
-      }
-      const resultJSON = JSON.parse(resultStr);
-      this.fnSetZecPrice(resultJSON.current_price);
-    } catch (error) {
-      console.error(`zec_price threw:`, error);
     }
   }
 


### PR DESCRIPTION
## What

The clearnet ZEC price fetch is removed end to end, and the price
display goes dark. This is the zingo-pc slice of ADR 0024
("Consumers converge on a zingolib-owned mixnet surface", recorded in
the zingolib repo), whose arc 6 reinstates the mixnet-only price rule
and whose consequences section ratifies pc's darkness as deliberate:
the app must not fetch price over clearnet while its future privacy
posture claims otherwise.

Removed, layer by layer:

- `src/rpc/rpc.ts`: the `getZecPrice` method, its two scheduler call
  sites, and the `fnSetZecPrice` constructor wiring.
- `src/root/Routes.tsx`: the constructor argument (the state and its
  wallet-switch reset stay).
- `public/preload.js` and `public/electron.js`: the `native:zec_price`
  IPC relay.
- `native/src/lib.rs`: the `zec_price` neon export and its body.
- `src/native.node.d.ts`: the declaration.

The display machinery stays wired. `zecPrice` holds 0 and every USD
display renders the existing unified `USD --` fallback, so phase 3 of
the convergence re-lands price as a typed subscription without
rebuilding the render path. The per-transaction `zec_price` field on
value transfers is historical wallet data, not a live fetch, and is
untouched.

## Also

`docs/agents/adr0024-neon-boundary-map.md` records the phase-3
pre-work survey: the four-file call path, the 73-function export
surface with its stringly JSON returns and prose-only errors, the
absence of any native-to-JS push channel, the already-plumbed
`process.mas` discrimination (with a Flatpak attach question for
phase 3), and the dependency state, including the single direct
netutils import that retires once zingolib's phase-1 funnel reaches a
pinned rev.

## Verification

`cargo check` on the native crate and `tsc --noEmit` on the TS tree
both pass. The jest suite needs a neon build and was not run here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
