### PR TITLE
fix: shorten Copy Address feedback to 1.5s

### DIFF
--- a/src/components/common/useCopy.ts
+++ b/src/components/common/useCopy.ts
@@ -5,9 +5,8 @@ import { clipboard } from "../../electronBridge";
 // Exposes a `copied` flag that auto-resets after `timeoutMs` so callers can show
 // a transient "Copied!" indicator and disable the trigger while it's true.
 //
-// The timeout defaults to 3s. Pass 5000 (or longer) for explicit "Copy X"
-// buttons where the user is more likely to look away after clicking; 1500 is a
-// good fit for inline click-to-copy regions where the feedback should be quick.
+// The timeout defaults to 3s; every caller in the app currently passes 1500 so
+// copy feedback feels consistently quick.
 export function useCopy(timeoutMs: number = 3000): { copied: boolean; copy: (text: string) => void } {
   const [copied, setCopied] = useState<boolean>(false);
   const timerRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);

--- a/src/components/receive/components/AddressBlock.tsx
+++ b/src/components/receive/components/AddressBlock.tsx
@@ -54,7 +54,7 @@ const AddressBlock: React.FC<AddressBlockProps> = ({
   } = context;
   const address_address = address.encoded_address;
 
-  const { copied, copy } = useCopy(5000);
+  const { copied, copy } = useCopy(1500);
   const [creating, setCreating] = useState<boolean>(false);
   const [shieldFee, setShieldFee] = useState<number>(0);
 


### PR DESCRIPTION
## Summary
- Receive page "Copy Address" button showed "Copied!" (and stayed disabled) for 5s; every other copy interaction in the app (sidebar UFVK/birthday, tx modal, address book) uses 1.5s. Align it to 1.5s.
- Update the `useCopy` doc comment, which still recommended 5000 for explicit copy buttons.

## Test plan
- [x] `scripts/test.js src/components/receive/components/AddressBlock.test.tsx` — 17 passed
- [x] addressBook / messages / sideBar / history suites — 183 passed
- [x] Manual: Receive → Copy Address, "Copied!" reverts after ~1.5s