### PR TITLE
fix: keep the swap records of a wallet whose file outlives the delete

### DIFF
--- a/src/__mocks__/electronBridge.ts
+++ b/src/__mocks__/electronBridge.ts
@@ -10,6 +10,9 @@ export const native = {
   set_wallet_base_dir: jest.fn(),
   start_security_scoped_access: jest.fn(),
   get_latest_block_server: jest.fn(),
+  // AddNewWallet (delete)
+  stop_sync: jest.fn(),
+  delete_wallet: jest.fn(),
   // Send
   send: jest.fn(),
   get_spendable_balance_with_address: jest.fn(),

--- a/src/components/addNewWallet/AddNewWallet.test.tsx
+++ b/src/components/addNewWallet/AddNewWallet.test.tsx
@@ -2,12 +2,25 @@ import React from "react";
 import { fireEvent, screen, waitFor, within } from "@testing-library/react";
 import { render } from "../../test-utils";
 import AddNewWallet from "./AddNewWallet";
-import { ipcRenderer } from "../../electronBridge";
+import { ipcRenderer, native } from "../../electronBridge";
 import fetchServerList from "../../utils/fetchServerList";
-import { ServerChainNameEnum, ServerClass } from "../appstate";
+import { CreationTypeEnum, ServerChainNameEnum, ServerClass } from "../appstate";
+import { SwapStore, readCurrentWalletFingerprint } from "../../swap";
+import { useSwapService } from "../../context/ContextSwapService";
 
 jest.mock("../../electronBridge");
 jest.mock("../../utils/fetchServerList");
+jest.mock("../../rpc/rpc", () => ({ __esModule: true, default: { deinitialize: jest.fn() } }));
+// Named rather than automocked: the delete flow only reaches `clearForWallet`
+// and the fingerprint read, and a factory keeps the real store — with its
+// module-level wallet binding — out of the test entirely.
+jest.mock("../../swap", () => ({
+  SwapStore: { clearForWallet: jest.fn() },
+  readCurrentWalletFingerprint: jest.fn(),
+  createSwapService: jest.fn(),
+  swapRecordToValueTransfer: jest.fn(),
+}));
+jest.mock("../../context/ContextSwapService", () => ({ useSwapService: jest.fn() }));
 
 const mockSettings = { serveruri: "", serverchain_name: "main", serverselection: "" };
 
@@ -24,7 +37,15 @@ const liveServer = (uri: string, chain = ServerChainNameEnum.mainChainName): Ser
 beforeEach(() => {
   (ipcRenderer.invoke as jest.Mock).mockResolvedValue(mockSettings);
   liveList.mockReset().mockResolvedValue([]);
+  (useSwapService as jest.Mock).mockReturnValue(null);
+  (SwapStore.clearForWallet as jest.Mock).mockResolvedValue(undefined);
+  (readCurrentWalletFingerprint as jest.Mock).mockResolvedValue(FINGERPRINT);
+  (native.wallet_exists as jest.Mock).mockResolvedValue(true);
+  (native.stop_sync as jest.Mock).mockResolvedValue("ok");
+  (native.delete_wallet as jest.Mock).mockResolvedValue("ok");
 });
+
+const FINGERPRINT = "ufvktail16charss";
 
 const baseProps = {
   closeModal: jest.fn(),
@@ -203,5 +224,87 @@ describe("AddNewWallet delete confirmation", () => {
 
     await waitFor(() => expect(openConfirmModal).toHaveBeenCalled());
     expect(baseProps.clearTimers).not.toHaveBeenCalled();
+  });
+});
+
+describe("AddNewWallet delete and swap records", () => {
+  const walletOfType = (creationType: CreationTypeEnum) =>
+    ({
+      id: 1,
+      alias: "Savings",
+      fileName: "zingo-wallet.dat",
+      uri: "https://mainnet.example:443",
+      chain_name: ServerChainNameEnum.mainChainName,
+      creationType,
+    }) as never;
+
+  /** Open the delete screen, click through, and accept the confirmation. */
+  const confirmDelete = async (creationType: CreationTypeEnum) => {
+    const openConfirmModal = jest.fn();
+    render(<AddNewWallet {...baseProps} />, {
+      initialRoute: { pathname: "/addnewwallet", state: { mode: "delete" } } as never,
+      contextOverrides: { currentWallet: walletOfType(creationType), openConfirmModal },
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /^delete wallet$/i }));
+    await waitFor(() => expect(openConfirmModal).toHaveBeenCalled());
+    // The modal's accept callback is what actually deletes.
+    openConfirmModal.mock.calls[0][2]();
+    return openConfirmModal;
+  };
+
+  // The wallet file goes, so the records that describe swaps made from it have
+  // nothing left to belong to.
+  it("clears the swap bucket when the wallet file is deleted with the wallet", async () => {
+    await confirmDelete(CreationTypeEnum.Seed);
+
+    await waitFor(() => expect(SwapStore.clearForWallet).toHaveBeenCalledWith(FINGERPRINT));
+    await waitFor(() => expect(native.delete_wallet).toHaveBeenCalled());
+  });
+
+  // A wallet opened from an existing .DAT is not destroyed by this flow — the
+  // file stays put and can be opened again. Clearing the bucket would leave
+  // that reopened wallet with an empty history for a delete that only ever
+  // removed a list entry, so the records stay with the file.
+  it("keeps the swap bucket when the wallet was opened from a file left on disk", async () => {
+    await confirmDelete(CreationTypeEnum.File);
+
+    await waitFor(() => expect(baseProps.setCurrentWallet).toHaveBeenCalledWith(null));
+    expect(SwapStore.clearForWallet).not.toHaveBeenCalled();
+    expect(native.delete_wallet).not.toHaveBeenCalled();
+  });
+
+  // The in-flight warning tells the user what they lose. For a file-backed
+  // wallet that is the tracking, not the record, and saying otherwise would
+  // send someone hunting for a seed phrase they do not need.
+  it("warns that a file-backed wallet keeps its in-flight swap record", async () => {
+    (useSwapService as jest.Mock).mockReturnValue({ hasInflightDeposits: jest.fn().mockResolvedValue(true) });
+    const openConfirmModal = jest.fn();
+    render(<AddNewWallet {...baseProps} />, {
+      initialRoute: { pathname: "/addnewwallet", state: { mode: "delete" } } as never,
+      contextOverrides: { currentWallet: walletOfType(CreationTypeEnum.File), openConfirmModal },
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /^delete wallet$/i }));
+
+    await waitFor(() => expect(openConfirmModal).toHaveBeenCalled());
+    const body: string = openConfirmModal.mock.calls[0][1];
+    expect(body).toContain("open the file again");
+    expect(body).not.toContain("seed phrase");
+  });
+
+  // The same warning for every other wallet keeps saying what it said.
+  it("warns that a seed-backed wallet loses its in-flight swap record", async () => {
+    (useSwapService as jest.Mock).mockReturnValue({ hasInflightDeposits: jest.fn().mockResolvedValue(true) });
+    const openConfirmModal = jest.fn();
+    render(<AddNewWallet {...baseProps} />, {
+      initialRoute: { pathname: "/addnewwallet", state: { mode: "delete" } } as never,
+      contextOverrides: { currentWallet: walletOfType(CreationTypeEnum.Seed), openConfirmModal },
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /^delete wallet$/i }));
+
+    await waitFor(() => expect(openConfirmModal).toHaveBeenCalled());
+    expect(openConfirmModal.mock.calls[0][1]).toContain("removes the record that tracks it");
   });
 });

--- a/src/components/addNewWallet/AddNewWallet.tsx
+++ b/src/components/addNewWallet/AddNewWallet.tsx
@@ -600,8 +600,10 @@ const AddNewWallet: React.FC<AddNewWalletProps> = ({
   };
 
   /**
-   * Deleting the wallet is the one flow that destroys its swap records, so it
-   * is the one flow that has to ask first.
+   * Deleting the wallet is the one flow that stops its swaps being tracked, so
+   * it is the one flow that has to ask first. For a wallet opened from an
+   * existing file the stop is temporary and the records survive; everywhere
+   * else the delete destroys them.
    *
    * The question is whether any swap still has a deposit the provider can see
    * and has not settled. Outbound, deleting loses the tracking record while
@@ -626,11 +628,21 @@ const AddNewWallet: React.FC<AddNewWalletProps> = ({
       }
     }
     if (inflight) {
+      // A wallet opened from an existing file keeps both halves: the file stays
+      // on disk and so does its swap bucket. Warning that the tracking record
+      // is about to be lost would be the wrong warning — what it loses is the
+      // tracking itself, until the file is opened again.
+      const keepsItsRecords: boolean = currentWallet.creationType === CreationTypeEnum.File;
       openConfirmModal(
         "Delete Wallet",
-        "A swap belonging to this wallet is still in flight: its deposit has been paid and the provider has not " +
-          "settled it yet. Deleting now removes the record that tracks it, and if the swap pays out to this wallet " +
-          "you will need its seed phrase to reach those funds. Delete anyway?",
+        keepsItsRecords
+          ? "A swap belonging to this wallet is still in flight: its deposit has been paid and the provider has not " +
+              "settled it yet. This wallet was opened from an existing wallet file, so both that file and the swap's " +
+              "record stay on this computer — open the file again to pick the swap back up. Nothing tracks it in the " +
+              "meantime. Delete anyway?"
+          : "A swap belonging to this wallet is still in flight: its deposit has been paid and the provider has not " +
+              "settled it yet. Deleting now removes the record that tracks it, and if the swap pays out to this " +
+              "wallet you will need its seed phrase to reach those funds. Delete anyway?",
         () => {
           performDelete();
         },
@@ -684,11 +696,22 @@ const AddNewWallet: React.FC<AddNewWalletProps> = ({
           // the only way to name this wallet's swap bucket — out of reach.
           // Skipped rather than guessed when the fingerprint comes back empty:
           // a wrong key would wipe a different wallet's records.
-          const fingerprint = await readCurrentWalletFingerprint();
-          if (fingerprint) {
-            await SwapStore.clearForWallet(fingerprint);
+          //
+          // A wallet opened from an existing .DAT is the exception, because the
+          // delete below leaves that file where it was. The wallet outlives the
+          // entry being removed here and can be opened again tomorrow, and it
+          // would come back to an empty history: same file, same UFVK, so the
+          // same bucket key, with the records cleared by a delete that never
+          // destroyed the wallet. The records stay with the file that stays.
+          if (currentWallet.creationType === CreationTypeEnum.File) {
+            console.log("Delete Wallet: opened from an existing file, keeping its swap records with it");
           } else {
-            console.log("Delete Wallet: no fingerprint, leaving the swap bucket alone");
+            const fingerprint = await readCurrentWalletFingerprint();
+            if (fingerprint) {
+              await SwapStore.clearForWallet(fingerprint);
+            } else {
+              console.log("Delete Wallet: no fingerprint, leaving the swap bucket alone");
+            }
           }
           await RPC.deinitialize();
 


### PR DESCRIPTION
Deleting a wallet opened from an existing `.DAT` leaves that file on disk — `performDelete` already skips `delete_wallet` for `CreationTypeEnum.File`. But it still cleared the swap bucket, so reopening the same file gave the same UFVK, the same bucket key, and an empty history, for a delete that never destroyed the wallet.

The clear is now skipped for that creation type. Everything else is unchanged: seed- and UFVK-backed wallets still wipe their bucket, and the empty-fingerprint case still skips it.

The in-flight warning branches with it. It said the tracking record was about to be lost and pointed at the seed phrase — false for a file-backed wallet, where the record survives and only the tracking stops until the file is opened again.

Four tests cover both delete paths and both warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
