### PR TITLE
Follow zingolib dev for the native layer

### DIFF
--- a/native/Cargo.lock
+++ b/native/Cargo.lock
@@ -2011,7 +2011,7 @@ dependencies = [
 [[package]]
 name = "pepper-sync"
 version = "0.5.0"
-source = "git+https://github.com/dorianvp/zingolib?branch=feat%2Fadd-opreturn#75490e1f1ab5f7a5eca6cd250ee7c0666d5d3a2a"
+source = "git+https://github.com/zingolabs/zingolib?rev=3035fe5d53d3a2bca76cfef221789f964ca7b388#3035fe5d53d3a2bca76cfef221789f964ca7b388"
 dependencies = [
  "bip32",
  "byteorder",
@@ -4198,7 +4198,7 @@ dependencies = [
 [[package]]
 name = "zingo-memo"
 version = "0.1.1"
-source = "git+https://github.com/dorianvp/zingolib?branch=feat%2Fadd-opreturn#75490e1f1ab5f7a5eca6cd250ee7c0666d5d3a2a"
+source = "git+https://github.com/zingolabs/zingolib?rev=3035fe5d53d3a2bca76cfef221789f964ca7b388#3035fe5d53d3a2bca76cfef221789f964ca7b388"
 dependencies = [
  "zcash_address",
  "zcash_encoding",
@@ -4209,7 +4209,7 @@ dependencies = [
 [[package]]
 name = "zingo-net-diag"
 version = "0.1.0"
-source = "git+https://github.com/dorianvp/zingolib?branch=feat%2Fadd-opreturn#75490e1f1ab5f7a5eca6cd250ee7c0666d5d3a2a"
+source = "git+https://github.com/zingolabs/zingolib?rev=3035fe5d53d3a2bca76cfef221789f964ca7b388#3035fe5d53d3a2bca76cfef221789f964ca7b388"
 dependencies = [
  "serde",
 ]
@@ -4217,7 +4217,7 @@ dependencies = [
 [[package]]
 name = "zingo-netutils"
 version = "5.0.1"
-source = "git+https://github.com/dorianvp/zingolib?branch=feat%2Fadd-opreturn#75490e1f1ab5f7a5eca6cd250ee7c0666d5d3a2a"
+source = "git+https://github.com/zingolabs/zingolib?rev=3035fe5d53d3a2bca76cfef221789f964ca7b388#3035fe5d53d3a2bca76cfef221789f964ca7b388"
 dependencies = [
  "http",
  "hyper-util",
@@ -4239,7 +4239,7 @@ dependencies = [
 [[package]]
 name = "zingo-price"
 version = "0.1.0"
-source = "git+https://github.com/dorianvp/zingolib?branch=feat%2Fadd-opreturn#75490e1f1ab5f7a5eca6cd250ee7c0666d5d3a2a"
+source = "git+https://github.com/zingolabs/zingolib?rev=3035fe5d53d3a2bca76cfef221789f964ca7b388#3035fe5d53d3a2bca76cfef221789f964ca7b388"
 dependencies = [
  "byteorder",
  "serde",
@@ -4253,7 +4253,7 @@ dependencies = [
 [[package]]
 name = "zingo-status"
 version = "0.2.1"
-source = "git+https://github.com/dorianvp/zingolib?branch=feat%2Fadd-opreturn#75490e1f1ab5f7a5eca6cd250ee7c0666d5d3a2a"
+source = "git+https://github.com/zingolabs/zingolib?rev=3035fe5d53d3a2bca76cfef221789f964ca7b388#3035fe5d53d3a2bca76cfef221789f964ca7b388"
 dependencies = [
  "byteorder",
  "zcash_protocol",
@@ -4271,7 +4271,7 @@ dependencies = [
 [[package]]
 name = "zingolib"
 version = "6.0.0"
-source = "git+https://github.com/dorianvp/zingolib?branch=feat%2Fadd-opreturn#75490e1f1ab5f7a5eca6cd250ee7c0666d5d3a2a"
+source = "git+https://github.com/zingolabs/zingolib?rev=3035fe5d53d3a2bca76cfef221789f964ca7b388#3035fe5d53d3a2bca76cfef221789f964ca7b388"
 dependencies = [
  "append-only-vec",
  "bech32",

--- a/native/Cargo.toml
+++ b/native/Cargo.toml
@@ -31,19 +31,23 @@ crate-type = ["cdylib"]
 # crates.io + 0.30 git coexist, orchard 0.15.4). See the [patch] note below on
 # the librustzcash rev pin zcash_pool_migration requires.
 #
-# Pinned to the OP_RETURN branch (zingolib PR #2469) until it lands on dev:
-# swaps need the null-data output and the ZIP 320 ephemeral route, neither of
-# which dev's zcash_client_backend path can express. That branch also carries
-# ~300 commits of dev the previous pin predated, which is why this bump moved
-# attach_mixnet, the SplitStep names, the transmit_* renames, and the editorial
-# layer below.
+# The OP_RETURN work (zingolib PR #2469) has landed on dev, so the fork pin is
+# gone and these follow zingolabs/zingolib. By rev rather than by branch, so a
+# build stays reproducible (ADR 0024 rule 7); bump it deliberately.
 #
-# `perspective` is that editorial layer (value transfers, messages, the
-# total_*_to_address reductions). dev moved it behind a default-off feature, so
-# the UI's read model has to opt in.
-zingolib = { git = "https://github.com/dorianvp/zingolib", branch = "feat/add-opreturn", features = ["nym", "perspective"] }
-pepper-sync = { git = "https://github.com/dorianvp/zingolib", branch = "feat/add-opreturn" }
-zingo-netutils = { git = "https://github.com/dorianvp/zingolib", branch = "feat/add-opreturn" }
+# dev renamed the surface swaps depend on: OpReturnData moved to
+# wallet::transparent, and the one-step propose_swap_deposit became
+# propose_send_with_op_return, which stores a proposal that
+# send_stored_proposal then transmits, resuming at the OP_RETURN step when the
+# deshield already went out. The native layer was adapted to that shape
+# alongside this bump.
+#
+# `perspective` is the editorial layer (value transfers, messages, the
+# total_*_to_address reductions), behind a default-off feature, so the UI's
+# read model has to opt in.
+zingolib = { git = "https://github.com/zingolabs/zingolib", rev = "3035fe5d53d3a2bca76cfef221789f964ca7b388", features = ["nym", "perspective"] }
+pepper-sync = { git = "https://github.com/zingolabs/zingolib", rev = "3035fe5d53d3a2bca76cfef221789f964ca7b388" }
+zingo-netutils = { git = "https://github.com/zingolabs/zingolib", rev = "3035fe5d53d3a2bca76cfef221789f964ca7b388" }
 
 # These must match zingolib's workspace versions exactly, not merely be
 # semver-compatible with them. Two versions of `zcash_keys` resolve to two

--- a/native/src/lib.rs
+++ b/native/src/lib.rs
@@ -85,7 +85,7 @@ use tokio::runtime::Runtime;
 use zcash_protocol::memo::MemoBytes;
 use zingolib::data::receivers::transaction_request_from_receivers;
 use zingolib::mixnet::ExitNodeId;
-use zingolib::wallet::op_return::OpReturnData;
+use zingolib::wallet::transparent::OpReturnData;
 use zingolib::ActivationHeights;
 use zingo_netutils::{GrpcIndexer, Indexer};
 
@@ -2888,15 +2888,24 @@ fn send_swap_deposit(mut cx: FunctionContext) -> JsResult<JsPromise> {
             };
 
             Ok(RT.block_on(async move {
-                match lightclient
-                    .propose_swap_deposit(&vault_address, amount, memo, AccountId::ZERO, true)
+                // Two calls rather than one: the proposal is stored, and
+                // sending it is what transmits. The pair stays behind this
+                // single entry point, so the swap flow still asks once and
+                // gets every txid back.
+                if let Err(e) = lightclient
+                    .propose_send_with_op_return(&vault_address, amount, memo, AccountId::ZERO)
                     .await
                 {
+                    return object! { "error" => cause_chain(&e) }.pretty(2);
+                }
+                // Resumes at the OP_RETURN step when the deshield already
+                // went out, which is the case this shape used to lose.
+                match lightclient.send_stored_proposal(true).await {
                     // Deshield first, carrier last — the order the swap
                     // flow reads, which takes the last as the deposit the
                     // provider watches.
-                    Ok(reports) => object! {
-                        "txids" => reports.iter().map(|report| report.txid.to_string()).collect::<Vec<_>>()
+                    Ok(txids) => object! {
+                        "txids" => txids.iter().map(|txid| txid.to_string()).collect::<Vec<_>>()
                     },
                     Err(e) => object! { "error" => cause_chain(&e) },
                 }

--- a/src/components/swap/SwapDetailModal.tsx
+++ b/src/components/swap/SwapDetailModal.tsx
@@ -117,6 +117,11 @@ const SwapDetailModal: React.FC<SwapDetailModalProps> = ({
 
   const uniqueHashRows = hashRowsForRecord(record);
 
+  // What the provider said about an ending nobody asked for. A refund says it
+  // in `refundInfo`, a failure in `failureReason`; both reached the record and
+  // neither reached the screen.
+  const endedBadlyReason = record.refundInfo?.refundReason ?? record.failureReason;
+
   const removable = canRemoveSwap(record.status);
 
   // A deposit the provider can see is what turns a reserved swap into a
@@ -271,6 +276,7 @@ const SwapDetailModal: React.FC<SwapDetailModalProps> = ({
             <Field label="Provider" value={providerLongLabel(record.provider)} />
             <Field label="Direction" value={isOutbound ? "Outbound" : "Inbound"} />
             {!!record.routeId && <Field label="Route id" value={record.routeId} />}
+            {!!record.providerOrderId && <CopyField label="Order id" value={record.providerOrderId} copy={copy} />}
           </FieldRow>
 
           <FieldRow>
@@ -313,6 +319,13 @@ const SwapDetailModal: React.FC<SwapDetailModalProps> = ({
                 Fee breakdown
               </button>
             </FieldRow>
+          )}
+
+          {!!endedBadlyReason && (
+            <>
+              <SectionHeader label={record.refundInfo?.refundReason ? "Refund" : "Failure"} />
+              <Field label="Reason" value={endedBadlyReason} />
+            </>
           )}
 
           <SectionHeader label="Addresses" />

--- a/src/swap/hashRowsForRecord.test.ts
+++ b/src/swap/hashRowsForRecord.test.ts
@@ -60,6 +60,25 @@ describe("hashRowsForRecord", () => {
     expect(rows).toEqual([{ label: "Broadcast", value: HASH_A }]);
   });
 
+  // Last of the list, because it is the one that only exists when the swap
+  // did not happen.
+  it("lists the transaction that returned the deposit", () => {
+    const rows = hashRowsForRecord(record({ observedDepositTxHash: HASH_A, refundInfo: { refundTxHash: HASH_B } }));
+
+    expect(rows).toEqual([
+      { label: "Deposit", value: HASH_A },
+      { label: "Refund", value: HASH_B },
+    ]);
+  });
+
+  it("leaves out a placeholder refund hash", () => {
+    const rows = hashRowsForRecord(
+      record({ observedDepositTxHash: HASH_A, refundInfo: { refundTxHash: PLACEHOLDER } }),
+    );
+
+    expect(rows).toEqual([{ label: "Deposit", value: HASH_A }]);
+  });
+
   it("has nothing to show for a swap with no transactions yet", () => {
     expect(hashRowsForRecord(record())).toEqual([]);
   });

--- a/src/swap/hashRowsForRecord.ts
+++ b/src/swap/hashRowsForRecord.ts
@@ -49,6 +49,12 @@ export function hashRowsForRecord(record: SwapRecordType): HashRowType[] {
     rows.push({ label: "Destination", value: record.destinationTxHash as string });
   }
 
+  // Last, because it is the one that only exists when the swap did not
+  // happen: the transaction that brought the deposit back.
+  if (isRealLegHash(record.refundInfo?.refundTxHash)) {
+    rows.push({ label: "Refund", value: record.refundInfo?.refundTxHash as string });
+  }
+
   const seen = new Set<string>();
   return rows.filter((row) => {
     if (seen.has(row.value)) return false;

--- a/src/swap/providers/trackUpdate.test.ts
+++ b/src/swap/providers/trackUpdate.test.ts
@@ -331,3 +331,81 @@ describe("applyDefaultTrackUpdate", () => {
     expect(before.status).toBe(SwapStatusEnum.Pending);
   });
 });
+
+/**
+ * Shaped after a real Flashnet refund on mainnet: the deposit landed and
+ * completed on the sell chain, the provider leg refunded carrying the order
+ * id and the reason, and a second transfer on the sell chain brought the
+ * funds back. Everything the user needs to chase it was in this response and
+ * none of it reached the record.
+ */
+describe("applyDefaultTrackUpdate on a refund", () => {
+  const REFUND_HASH = "c".repeat(64);
+  const REASON = "Order processing failed. Contact support with this order ID.";
+
+  const refunded: TrackResponseType = {
+    status: "refunded",
+    trackingStatus: "refunded",
+    meta: { refundReason: REASON },
+    legs: [
+      { chainId: "zcash", type: "native_send", status: "completed", hash: DEPOSIT_HASH },
+      {
+        chainId: "spark",
+        type: "swap",
+        status: "refunded",
+        hash: ZERO_HASH,
+        meta: { providerOrderId: "ord_01a09310", refundReason: REASON },
+      },
+      { chainId: "zcash", type: "native_send", status: "refunded", hash: REFUND_HASH },
+    ],
+  };
+
+  it("keeps the reason the provider gave for handing the deposit back", () => {
+    const updated = applyDefaultTrackUpdate(record(), refunded);
+
+    expect(updated.status).toBe(SwapStatusEnum.Refunded);
+    expect(updated.refundInfo?.refundReason).toBe(REASON);
+  });
+
+  // The deposit leg sits on the same chain and carries a real hash, so the
+  // refunded status is what picks the right transaction out, not the chain.
+  it("takes the transaction that returned the funds, not the one that sent them", () => {
+    const updated = applyDefaultTrackUpdate(record(), refunded);
+
+    expect(updated.refundInfo?.refundTxHash).toBe(REFUND_HASH);
+  });
+
+  // The provider asks for this by name when refusing an order, and it was
+  // reaching the app and going nowhere.
+  it("keeps the provider order id", () => {
+    const updated = applyDefaultTrackUpdate(record(), refunded);
+
+    expect(updated.providerOrderId).toBe("ord_01a09310");
+  });
+
+  // The real refund reported zero on both the swap leg and the returning
+  // transfer while returning the deposit in full. A figure read from there
+  // would tell the user they got nothing back.
+  it("claims no refunded amount, because the ones reported are not to be trusted", () => {
+    const updated = applyDefaultTrackUpdate(record(), { ...refunded, toAmount: "0" });
+
+    expect(updated.refundInfo?.refundedAmountText).toBeUndefined();
+    expect(updated.refundInfo?.depositedAmountText).toBeUndefined();
+  });
+
+  it("leaves the refund untouched while the swap is still running", () => {
+    const updated = applyDefaultTrackUpdate(record(), { status: "PROCESSING", legs: refunded.legs });
+
+    expect(updated.refundInfo).toBeUndefined();
+  });
+
+  // A second tick of the poller must not lose what the first one learned.
+  it("keeps what it already knew when a later response says less", () => {
+    const first = applyDefaultTrackUpdate(record(), refunded);
+    const second = applyDefaultTrackUpdate(first, { status: "refunded" });
+
+    expect(second.refundInfo?.refundReason).toBe(REASON);
+    expect(second.refundInfo?.refundTxHash).toBe(REFUND_HASH);
+    expect(second.providerOrderId).toBe("ord_01a09310");
+  });
+});

--- a/src/swap/providers/trackUpdateBase.ts
+++ b/src/swap/providers/trackUpdateBase.ts
@@ -19,7 +19,9 @@ import { mapSwapStatus, mapTrackingStatus } from "./statusMapping";
  *     first-leg / last-leg heuristic when no leg carries a chain hint.
  *   - Stamps `firstObservedAtMs` on the first non-pre-broadcast observation
  *     and `terminalAtMs` on the transition into a terminal status.
- *   - Captures `failureReason` only when the new status is `Failed`.
+ *   - Captures `failureReason` only when the new status is `Failed`, and the
+ *     refund reason and refund transaction only when it is `Refunded`.
+ *   - Keeps the provider order id whatever the outcome.
  */
 export function applyDefaultTrackUpdate(record: SwapRecordType, response: TrackResponseType): SwapRecordType {
   const nowMs = Date.now();
@@ -68,6 +70,17 @@ export function applyDefaultTrackUpdate(record: SwapRecordType, response: TrackR
   // polling.
   const providerExplorerUrl = pickProviderExplorerUrl(response) ?? record.providerExplorerUrl;
 
+  // Kept for every swap, not only a failed one: it is the name the provider
+  // answers to about this order, and the moment it is wanted is the moment
+  // the app can no longer reach the provider to ask.
+  const providerOrderId = pickProviderOrderId(response) ?? record.providerOrderId;
+
+  // A refund is the provider handing the deposit back and saying why. The
+  // reason rides in `meta`, and the transaction that returned the funds is a
+  // leg of its own on the chain the deposit came from — not the deposit leg,
+  // which sits on that same chain and completed.
+  const refundInfo = nextStatus === SwapStatusEnum.Refunded ? refundInfoFrom(record, response) : record.refundInfo;
+
   const reachedTerminalNow = !isTerminalStatus(record.status) && isTerminalStatus(nextStatus);
 
   return {
@@ -78,6 +91,8 @@ export function applyDefaultTrackUpdate(record: SwapRecordType, response: TrackR
     destinationTxHash,
     actualReceiveAmount,
     providerExplorerUrl,
+    providerOrderId,
+    refundInfo,
     failureReason:
       nextStatus === SwapStatusEnum.Failed ? (response.failureReason ?? record.failureReason) : record.failureReason,
     firstObservedAtMs: record.firstObservedAtMs ?? nowMs,
@@ -103,6 +118,77 @@ function pickProviderExplorerUrl(response: TrackResponseType): string | undefine
     }
   }
   return undefined;
+}
+
+/**
+ * The provider order id, wherever this provider puts it: top-level `meta`
+ * or the meta of whichever leg it runs. Flashnet ships it on the swap leg
+ * beside the explorer URL.
+ */
+function pickProviderOrderId(response: TrackResponseType): string | undefined {
+  const topLevel = (response.meta as { providerOrderId?: unknown })?.providerOrderId;
+  if (typeof topLevel === "string" && topLevel.length > 0) return topLevel;
+  if (response.legs) {
+    for (const leg of response.legs) {
+      const legId = (leg.meta as { providerOrderId?: unknown })?.providerOrderId;
+      if (typeof legId === "string" && legId.length > 0) return legId;
+    }
+  }
+  return undefined;
+}
+
+/**
+ * What a refunded response adds to what the record already knew.
+ *
+ * Only the reason and the transaction: the amounts a refund reports are not
+ * to be trusted. A real Flashnet refund came back with `toAmount: "0"` on
+ * both the swap leg and the returning transfer while the deposit was in fact
+ * returned in full, so a figure taken from there would understate what the
+ * user got back. The record already holds what was deposited.
+ */
+function refundInfoFrom(record: SwapRecordType, response: TrackResponseType) {
+  const refundReason = pickRefundReason(response) ?? record.refundInfo?.refundReason;
+  const refundTxHash = pickRefundTxHash(response, record.sellAsset.chainId) ?? record.refundInfo?.refundTxHash;
+  if (refundReason === undefined && refundTxHash === undefined) return record.refundInfo;
+  return {
+    ...record.refundInfo,
+    ...(refundReason !== undefined && { refundReason }),
+    ...(refundTxHash !== undefined && { refundTxHash }),
+  };
+}
+
+/** The provider words for why it refunded, top level or on any leg. */
+function pickRefundReason(response: TrackResponseType): string | undefined {
+  const topLevel = (response.meta as { refundReason?: unknown })?.refundReason;
+  if (typeof topLevel === "string" && topLevel.length > 0) return topLevel;
+  if (response.legs) {
+    for (const leg of response.legs) {
+      const legReason = (leg.meta as { refundReason?: unknown })?.refundReason;
+      if (typeof legReason === "string" && legReason.length > 0) return legReason;
+    }
+  }
+  return undefined;
+}
+
+/**
+ * The transaction that returned the funds: a refunded leg carrying a real
+ * hash. The deposit leg sits on the same chain and would match a naive
+ * chain-only search, so the refunded status is what selects it; the chain is
+ * then preferred among several, because the funds come back where they left
+ * from.
+ */
+function pickRefundTxHash(response: TrackResponseType, sellChainId: string): string | undefined {
+  if (!response.legs) return undefined;
+  const refunded = response.legs.filter((leg) => isRefundedLeg(leg.status) || isRefundedLeg(leg.trackingStatus));
+  const onSellChain = refunded.find(
+    (leg) => leg.chainId?.toLowerCase() === sellChainId.toLowerCase() && isRealLegHash(leg.hash),
+  );
+  if (onSellChain) return onSellChain.hash;
+  return refunded.find((leg) => isRealLegHash(leg.hash))?.hash;
+}
+
+function isRefundedLeg(status: string | undefined): boolean {
+  return status?.toLowerCase() === "refunded";
 }
 
 /**

--- a/src/swap/types/SwapRecordType.ts
+++ b/src/swap/types/SwapRecordType.ts
@@ -141,6 +141,14 @@ export type SwapRecordType = {
    * comes back to the app days later.
    */
   providerExplorerUrl?: string;
+
+  /**
+   * The provider name for this order, from `/track` (`meta.providerOrderId`,
+   * top level or on a leg). Support asks for it by that name — Flashnet
+   * refuses an order with "Contact support with this order ID" — so it is
+   * kept whatever the outcome, not only when one goes wrong.
+   */
+  providerOrderId?: string;
   /**
    * Destination-asset amount the provider actually paid out to the user,
    * in display units (string). Populated from `/track` once the outbound


### PR DESCRIPTION
The OP_RETURN work (zingolib PR #2469) has landed on dev, so the fork pin can go. The three crates now follow `zingolabs/zingolib` at `rev = 3035fe5d…` rather than a branch, so a build stays reproducible (ADR 0024 rule 7).

The whole native layer compiled against dev with **two** errors, both in the swap deposit:

| | before | after |
|---|---|---|
| memo type | `wallet::op_return::OpReturnData` | `wallet::transparent::OpReturnData` |
| deposit | `propose_swap_deposit(…)`, proposing and sending at once | `propose_send_with_op_return(…)` then `send_stored_proposal(true)` |

Nothing in the TypeScript layer changed for this. `send_swap_deposit` is still one call that answers with `{ txids: [...] }`, and the carrier is still last: dev builds the deshield reports first and pushes the OP_RETURN report onto them, so the transaction the provider watches remains the final entry.

## The ephemeral address still lines up

Worth stating, because the deposit's origin is what a swap provider reads as the refund destination, and the wallet hands that address to SwapKit before the deposit exists.

Both shapes use *the next unreserved refund address*, which is exactly what `derive_refund_address` answered with when the quote was made:

- The old call reserved it itself, inside the proposal (`generate_refund_addresses`). That is why `SwapExecute` reserves only for an inbound swap — an outbound one reserved its address by paying.
- dev derives it in the proposal without reserving, then in the send derives it again, **compares it against the one the proposal recorded, and refuses with `OpReturnSourceAddressStale` if they differ**, before reserving it and building the deshield.

So dev cannot quietly send from an address other than the one the swap was quoted against; it fails closed instead. It also rolls the reservation back when the deshield fails before transmission, which the old shape did not.

A mainnet Flashnet swap since confirmed the whole path: the provider refunded to exactly the refund-scope address this wallet derived and registered.

One pre-existing race is unchanged and worth knowing about: an inbound swap committed between an outbound quote and its deposit reserves an address, so the deposit would then originate from the following one while the provider was told the earlier one. That was equally true before this bump — both shapes take the next unreserved address at deposit time — so it is not a regression, but it could be closed by re-deriving immediately before the commit.

## Why a swap ended badly, and under what order id

That same Flashnet swap was refunded, and the response carried everything needed to chase it: the reason in plain words, the transaction that returned the funds, and the order id the provider's own message tells the user to quote. The app showed none of it — `refundInfo` was declared on the record and assigned nowhere, and `failureReason` was captured and rendered nowhere.

The track update now keeps the provider order id whatever the outcome, and on a refund the reason and the returning transaction. The detail states the reason and offers the order id to copy, and the transaction joins the list under its own name.

No amount is read from a refund. The real one reported `toAmount: "0"` on both the swap leg and the returning transfer while returning the deposit in full, so a figure taken from there would tell the user they got nothing back.

## What the bump buys

Beyond dropping the fork: sending through the stored proposal resumes at the OP_RETURN step when the deshield already went out. The old one-step call had no way to, so a failure between the two transactions left the deposit half paid.

## Testing

`cargo check` is clean, no errors and no warnings, and the JS suite passes (77 suites, 997 tests).

Not done yet, which is why this is a draft: a swap on mainnet against the new binary. The deposit path is the one that changed shape, so it wants a real deposit before this merges.

---

Parts of this branch were written with AI assistance (Claude Code); commits carry `Co-Authored-By` trailers where that applies.
