### PR TITLE
Fit the experimental swap banner to its sentence

### DIFF
--- a/src/components/swap/Swap.module.css
+++ b/src/components/swap/Swap.module.css
@@ -40,6 +40,21 @@
 }
 
 /*
+ * A banner that is one short sentence rather than something to act on. The
+ * box takes the width of the words instead of the width of the panel, which
+ * is what left a short line adrift at one edge of a full-width border, and
+ * the pair sits centred under what it qualifies. `max-width` keeps a longer
+ * sentence wrapping inside the panel rather than overflowing it.
+ */
+.warningbannercentred {
+  width: fit-content;
+  max-width: 100%;
+  margin-left: auto;
+  margin-right: auto;
+  text-align: center;
+}
+
+/*
  * The QR block on the deposit slip. The code renders on a light plate because
  * a scanner needs the dark-on-light contrast the app's dark background cannot
  * give it, and the plate is what keeps that from reading as a rendering bug.

--- a/src/components/swap/SwapExecute.tsx
+++ b/src/components/swap/SwapExecute.tsx
@@ -286,7 +286,7 @@ const SwapExecute: React.FC<SwapExecuteProps> = ({
 
         {/* Said again here, because the banner on the screen behind was read
             once and this is the press that spends the money. */}
-        <div className={swapStyles.warningbanner} style={{ marginTop: 12 }}>
+        <div className={`${swapStyles.warningbanner} ${swapStyles.warningbannercentred}`} style={{ marginTop: 12 }}>
           Swapping is experimental. Once this deposit is sent it cannot be called back.
         </div>
 


### PR DESCRIPTION
The notice above the deposit button in the swap review is one short line, but it sat inside a border that spanned the whole panel with the words at one edge, which read as a misaligned box rather than as a warning.

The box now takes the width of its text and the pair sits centred under what it qualifies, with a max-width so a longer sentence still wraps inside the panel rather than overflowing it. Done as a modifier class, so the other warning banners — which carry instructions to act on and want the full width — are untouched.

Verified: prettier, eslint, and the swap suites (45 tests).